### PR TITLE
Fixed deprecation warning: __new__ --> __cinit__

### DIFF
--- a/Code/Python/Bindings/MpegTsDemux/MpegTsDemux.pyx
+++ b/Code/Python/Bindings/MpegTsDemux/MpegTsDemux.pyx
@@ -44,7 +44,7 @@ cdef class MpegTsDemux:
 
     cdef char pidfilter[8192]
     
-    def __new__(self, pidfilter=None):
+    def __cinit__(self, pidfilter=None):
         cdef int pid
         
         self.frag_buffer = []


### PR DESCRIPTION
Fixed a bug preventing compilation and installing due to old syntax (using __new__ declaration) having been deprecated and replaced by new syntax (using __cinit__ declaration)