### PR TITLE
Bugfix: if DVB NIT table is 0..N-1 sections, then descriptors were be…

### DIFF
--- a/Code/Python/Kamaelia/Kamaelia/Device/DVB/Parse/ParseNetworkInformationTable.py
+++ b/Code/Python/Kamaelia/Kamaelia/Device/DVB/Parse/ParseNetworkInformationTable.py
@@ -395,6 +395,7 @@ class ParseNetworkInformationTable(component):
                 "actual_other" : self.acceptTables[table_id],
                 "current"      : current_next,
                 "network_id"   : network_id,
+                "descriptors"  : [],
               }
         services = {}
         
@@ -404,7 +405,6 @@ class ParseNetworkInformationTable(component):
             network_descriptors_length = ((ord(data[8])<<8) + ord(data[9])) & 0x0fff
             i=10
             network_descriptors_end = i+network_descriptors_length
-            msg['descriptors'] = []
             while i < network_descriptors_end:
                 descriptor, i = parseDescriptor(i,data)
                 msg['descriptors'].append(descriptor)


### PR DESCRIPTION
Found this bug while writing some code that was reading a complex real-life broadcast multiplex. Have verified this fix corrects the problem in my application.

The problem is that the array into which parsed descriptors were being placed was being cleared each time round the section processing loop.