### PR TITLE
Bugfix: missing import of sys

### DIFF
--- a/Code/Python/Kamaelia/Kamaelia/Internet/UDP.py
+++ b/Code/Python/Kamaelia/Kamaelia/Internet/UDP.py
@@ -129,6 +129,7 @@ does not implement a main() method.
 #
 
 import socket
+import sys
 import Axon
 
 # ---------------------------- # SimplePeer


### PR DESCRIPTION
UDP.py was missing "sys" module, meaning components would fail in the exception handler of receive_packet() (line 162)