### PR TITLE
New Documentation Harness Core

### DIFF
--- a/Code/Python/Kamaelia/Tools/NewDocGen/build_pdf.sh
+++ b/Code/Python/Kamaelia/Tools/NewDocGen/build_pdf.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+./kamaelia-docs.py > kamaelia_docs.rst
+pandoc kamaelia_docs.rst  -o kamaelia_docs.pdf
+
+echo "Docs built, to check:"
+echo "okular kamaelia_docs.pdf"
+

--- a/Code/Python/Kamaelia/Tools/NewDocGen/kamaelia-docs.py
+++ b/Code/Python/Kamaelia/Tools/NewDocGen/kamaelia-docs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python
+
+import os
+import importlib
+import modnames
+
+def has_docstring(thing):
+    return getattr(thing, "__doc__", False)
+
+def get_doctype(thing):
+    if getattr(thing, "__doctype__", False):
+        return getattr(thing, "__doctype__")
+    return "text/unknown"
+
+def getdoc(thing):
+    doctype = get_doctype(thing)
+    doc = getattr(thing, "__doc__", "")
+    return (doctype, doc)
+
+package_skiplist = [ "__pycache__", "__init__.py" ]
+
+def get_tree(basename):
+    #print("get_tree(", basename, ")" )
+    thing = importlib.import_module(basename)
+    thing_dir = thing.__path__[0]
+
+    modules = []
+    for i in os.listdir(thing_dir):
+        if i in package_skiplist:
+            continue
+        i_path = os.path.join(thing_dir, i)
+        if os.path.isdir(i_path):
+            subpackage_init_path = os.path.join(i_path, "__init__.py")
+            if os.path.exists(subpackage_init_path):
+                if os.path.isfile(subpackage_init_path):
+                    sub_modules = get_tree(basename + "." + i)
+                    modules.extend(sub_modules)
+
+        if os.path.isfile(i_path):
+            if i_path.endswith(".py"):
+                modules.append(basename + "." + i[:-3])
+
+    modules.sort()
+    return modules
+
+def heading_one(text):
+    print()
+    print("#" * len(text) )
+    print(text)
+    print("#" * len(text) )
+    print()
+
+def heading_two(text):
+    print()
+    print("*" * len(text) )
+    print(text)
+    print("*" * len(text) )
+    print()
+
+def heading_three(text):
+    print(text)
+    print("-" * len(text) )
+    print()
+
+def describe_name(name, module):
+    heading_three(name)
+    obj = getattr(module, name)
+    hasdocs = False
+    if hasattr(obj, "__doc__"):
+        if getattr(obj, "__doc__"):
+            print(getattr(obj, "__doc__"))
+            hasdocs = True
+    if not hasdocs:
+        print("NO DOCS")
+    print()
+
+def describe_module(modulename, mod_info, module, components, component_names):
+    #print("-"*100)
+    module_names = mod_info["module_names_no_private"]
+
+    heading_one(modulename)
+
+    if hasattr(module, "__doc__"):
+        docs = getattr(module, "__doc__")
+        if docs:
+            print(docs)
+        #else:
+            #print("NO DOCS")
+
+    if component_names:
+        heading_two("Components")
+        for name in component_names:
+            describe_name(name, module)
+        print()
+
+    other_names = []
+    for name in module_names:
+        if name in component_names:
+            continue
+        other_names.append(name)
+
+    if other_names:
+        heading_two("Other")
+        for name in other_names:
+            if name in component_names:
+                continue
+            describe_name(name, module)
+#            heading_three(name)
+            #print("*", name)
+
+
+print("- Kamaelia ---------------------------------------------------------------")
+modules = get_tree("Kamaelia")
+for modulename in modules:
+    #print(modulename)
+    try:
+        module = importlib.import_module(modulename)
+    except NotImplementedError as e:
+        #print("* Module", modulename, "has import error", *e.args)
+        continue
+    components = getattr(module, "__kamaelia_components__", [])
+    component_names = []
+    if components:
+        try:
+            [x.__name__ for x in components]
+#            print([x.__name__ for x in components])
+        except TypeError as e:
+            print("TYPE ERROR", e)
+            raise
+
+        component_names = [x.__name__ for x in components]
+
+    mod_info = modnames.get_module_names(modulename)
+
+    module_names = mod_info["module_names_no_private"]
+
+    strict_subset = True
+    for component in component_names:
+        if component not in module_names:
+            print("component %s not in namespace %s", component, modulename)
+            print(module_names)
+            print(module.__file__)
+            strict_subset = False
+            raise ValueError("component %s not in namespace %s", component, modulename)
+
+    #print("Defines:", mod_info["module_names_no_private"])
+
+    doc = module.__doc__
+
+    describe_module(modulename, mod_info, module, components, component_names)
+

--- a/Code/Python/Kamaelia/Tools/NewDocGen/modnames.py
+++ b/Code/Python/Kamaelia/Tools/NewDocGen/modnames.py
@@ -1,0 +1,196 @@
+#!/usr/bin/python
+
+import importlib
+import re
+import sys
+
+DEBUG = False
+def slurp(filename):
+    f = open(filename)
+    raw = f.read()
+    f.close()
+    return raw
+
+def debug(*argv, **argd):
+    if DEBUG:
+        print(*argv, **argd)
+
+def slurp_source(source_file):
+    source_lines = []
+    source = slurp(source_file).split("\n")
+    in_longstring = False
+    for line in source:
+        original_line = line
+        line = line.strip()
+        if line.startswith("#"):
+            debug("REJECTED1", original_line)
+            continue
+
+        if line.startswith('"""') and line.endswith('"""') and line.rfind('"""')>3:
+            debug("REJECTED2", line)
+            continue
+
+        if line.startswith("'''") and line.endswith("'''") and line.rfind("'''")>3:
+            debug("REJECTED3", line)
+            continue
+        
+        if line.startswith("'''") or line.startswith('"""'):
+            in_longstring = not in_longstring
+            debug("REJECTED4", line)
+            continue
+        if in_longstring:
+            debug("REJECTED5", line)
+            continue
+        debug("OK      ", original_line)
+        source_lines.append(original_line)
+    return source_lines
+
+def line_source(mod_source):
+    if type(mod_source) == str:
+        mod_lines = mod_source.split("\n")
+    else:
+        mod_lines = mod_source
+    for line in mod_lines:
+        yield line
+
+class ParseFail(Exception):
+    pass
+
+def find_imported_names(line, mod_source):
+    # We're not really doing a full parse, just looking for
+    # import lines and making assumptions about them.
+    # This will parse comments & doc strings too. so it's
+    # over-eager, but that's OK
+    
+    # strip comment
+    pline = line
+    line = re.sub("#.*$", "", line)
+    line = line.split(";")[0]
+    # strip whitespace
+    line = line.strip()
+    if not (line.startswith("from ") or line.startswith("import ") ):
+        raise ParseFail("Not Import Line", line)
+    if line.startswith("from"):
+        i = line.find("import") # We don't care where imported from
+        if i == -1:
+            raise ParseFail("Bad Import Line", line)
+        line = line[i:]
+    lazy_toks = line.split(" ")
+        
+    if len(lazy_toks) >= 4:
+        if lazy_toks[-2] == "as":
+            # We don't care how we got here
+            final_name = lazy_toks[-1]
+            return [final_name]
+    if len(lazy_toks) == 2:
+        if lazy_toks[0] == "import":
+            final_name = lazy_toks[1]
+            if "," not in final_name:
+                return [final_name]
+            else:
+                final_names = [ x for x in final_name.split(",") if x != ""]
+                return final_names
+    
+    assert lazy_toks[0] == "import"
+    lazy_toks = lazy_toks[1:]
+    if lazy_toks[-1].endswith(","):
+        print("Needed a continuation line...")
+        raise Exception("Fail")
+    final_toks = []
+    for tok in lazy_toks:
+        if "," in tok:
+            ntoks = [ x for x in tok.split(",") if x != ""]
+            final_toks += ntoks
+        else:
+            final_toks.append(tok)
+
+    return final_toks
+
+def get_module_names(full_module_name):
+
+    module = importlib.import_module(full_module_name)
+    modulename = full_module_name[full_module_name.rfind(".")+1:]
+    names = dir(module)
+    mod_source = line_source(slurp_source(module.__file__))
+    names_imported = []
+    while True:
+        try:
+            line = next(mod_source)
+        except StopIteration:
+            break
+        if "import" in line:
+            # Sigh, possibly a comment... Will need to deal with this
+            # print("LINE: ", line)
+            try:
+                parsed = find_imported_names(line, mod_source)
+                if parsed:
+                    #pass
+                    debug("NAMES DEFINED", parsed, line)
+                    names_imported += parsed
+                    if parsed == ['*']:
+                        print("NEED TO TIGHTEN UP IMPORTS", line)
+            except ParseFail as e:
+                # For now we don't really care
+                pass
+                # print("FAILED:", e, line)
+
+    module_names = [ x for x in names if x not in names_imported]
+    module_names_no_private = [ x for x in module_names if not x.startswith("_") ]
+    
+    debug("MODULE_NAMES", module_names_no_private)
+    debug("IMPORTED NAMES", names_imported)
+    
+    result = {"modulename" : modulename,
+            "full_module_name" : full_module_name,
+            "names" : names,
+            "names_imported" : names_imported,
+            "module_names" : module_names,
+            "module_names_no_private" : module_names_no_private,
+            }
+    return result
+
+def describe_module(mod_info):
+
+    print("---------------------------------------")
+    print("Short module name:", mod_info["modulename"])
+    print("---------------------------------------")
+    print("Full module name:", mod_info["full_module_name"])
+    print("---------------------------------------")
+    print("Names in the module:", mod_info["names"])
+    print("---------------------------------------")
+    print("Names imported:", mod_info["names_imported"])
+    print("---------------------------------------")
+    print("Names defined in module:", mod_info["module_names"] )
+    print("---------------------------------------")
+    if mod_info["modulename"] in mod_info["names"]:
+        other_names = [x for x in mod_info["module_names_no_private"] if x != mod_info["modulename"]]
+        firstname = r["modulename"]
+    else:
+        firstname = ""
+        other_names = mod_info["module_names_no_private"]
+    print("Useful Names defined in module:", firstname, other_names )
+    print("---------------------------------------")
+
+if __name__ == "__main__":
+
+    full_module_name= "Kamaelia.Visualisation.PhysicsGraph.RenderingParticle"
+    full_module_name= "Kamaelia.UI.OpenGL.OpenGLComponent"
+    full_module_name= "Kamaelia.Chassis.ConnectedServer"
+    full_module_name= "Kamaelia.Util.RateFilter"
+
+    # full_module_name= "Kamaelia.IPC"
+    # full_module_name= "Kamaelia.Support.Deprecate"
+
+    r = get_module_names(full_module_name)
+    describe_module(r)
+
+    testing = False
+    if testing:
+        source_path = "/home/michael/Development/00_not_as_current/kamaelia/Code/Python/Kamaelia/Kamaelia/Chassis/ConnectedServer.py"
+        lines = slurp_source(source_path)
+
+        print("Stripped--------------------------------------------------------------------")
+        for line in lines:
+            print(line)
+
+        sys.exit(0)


### PR DESCRIPTION
After the various recent changes to enable this, this code forms the basis of a new approach to autogenerating the documentation for the site. For the moment it accepts the fact that the docs are RST rather than markdown - but it would be nice to switch to markdown or docbook.

What this does:

* Takes a package entry point
* Finds all the modules within it
* Looks for all the components within those
* Generates a documentation page based on the module `__doc__` string, the components docstrings and other public names in the module
* It combines these into one large RST file
* It then generates an API reference file in the form of a PDF. (This step requires pandoc)

Currently that PDF is around 370 pages in length (very wide margins though!)
