### PR TITLE
Improve PDF Doc Build process

### DIFF
--- a/Code/Python/Kamaelia/Tools/NewDocGen/build_pdf.sh
+++ b/Code/Python/Kamaelia/Tools/NewDocGen/build_pdf.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-./kamaelia-docs.py > kamaelia_docs.rst
-pandoc kamaelia_docs.rst  -o kamaelia_docs.pdf
+./kamaelia-docs.py Kamaelia > Kamaelia_docs.rst
+pandoc Kamaelia_docs.rst  -o Kamaelia_docs.pdf
+
+./kamaelia-docs.py Axon > Axon_docs.rst
+pandoc Axon_docs.rst  -o Axon_docs.pdf
+
+cat Axon_docs.rst Kamaelia_docs.rst > AxonKamaelia_docs.rst
+pandoc AxonKamaelia_docs.rst  -o AxonKamaelia_docs.pdf
 
 echo "Docs built, to check:"
 echo "okular kamaelia_docs.pdf"

--- a/Code/Python/Kamaelia/Tools/NewDocGen/kamaelia-docs.py
+++ b/Code/Python/Kamaelia/Tools/NewDocGen/kamaelia-docs.py
@@ -108,44 +108,56 @@ def describe_module(modulename, mod_info, module, components, component_names):
 #            heading_three(name)
             #print("*", name)
 
+def usage():
+    p = sys.argv[0]
+    prog = p.split("/")[-1]
+    print("Usage:")
+    print("   %s package-name" % prog)
 
-print("- Kamaelia ---------------------------------------------------------------")
-modules = get_tree("Kamaelia")
-for modulename in modules:
-    #print(modulename)
-    try:
-        module = importlib.import_module(modulename)
-    except NotImplementedError as e:
-        #print("* Module", modulename, "has import error", *e.args)
-        continue
-    components = getattr(module, "__kamaelia_components__", [])
-    component_names = []
-    if components:
+if __name__ == "__main__":
+    
+    import sys
+    if len(sys.argv) != 2:
+        usage()
+        sys.exit(1)
+
+    docpackage = sys.argv[1]
+
+    print("- %s ---------------------------------------------------------------" % docpackage)
+    modules = get_tree(docpackage)
+    for modulename in modules:
         try:
-            [x.__name__ for x in components]
-#            print([x.__name__ for x in components])
-        except TypeError as e:
-            print("TYPE ERROR", e)
-            raise
+            module = importlib.import_module(modulename)
+        except NotImplementedError as e:
+            #print("* Module", modulename, "has import error", *e.args)
+            continue
+        components = getattr(module, "__kamaelia_components__", [])
+        component_names = []
+        if components:
+            try:
+                [x.__name__ for x in components]
+            except TypeError as e:
+                print("TYPE ERROR", e)
+                raise
 
-        component_names = [x.__name__ for x in components]
+            component_names = [x.__name__ for x in components]
 
-    mod_info = modnames.get_module_names(modulename)
+        mod_info = modnames.get_module_names(modulename)
 
-    module_names = mod_info["module_names_no_private"]
+        module_names = mod_info["module_names_no_private"]
 
-    strict_subset = True
-    for component in component_names:
-        if component not in module_names:
-            print("component %s not in namespace %s", component, modulename)
-            print(module_names)
-            print(module.__file__)
-            strict_subset = False
-            raise ValueError("component %s not in namespace %s", component, modulename)
+        strict_subset = True
+        for component in component_names:
+            if component not in module_names:
+                print("component %s not in namespace %s", component, modulename)
+                print(module_names)
+                print(module.__file__)
+                strict_subset = False
+                raise ValueError("component %s not in namespace %s", component, modulename)
 
-    #print("Defines:", mod_info["module_names_no_private"])
+        #print("Defines:", mod_info["module_names_no_private"])
 
-    doc = module.__doc__
+        doc = module.__doc__
 
-    describe_module(modulename, mod_info, module, components, component_names)
+        describe_module(modulename, mod_info, module, components, component_names)
 


### PR DESCRIPTION
Make kamaelia-docs.py able to be told which package to build, which potentially makes this more general, and also make the shell build script call it with both Axon and Kamaelia and use pandoc to generate 3 overall documentation PDFs. This results in a pretty large overall API document.