### PR TITLE
Update website to cover new release

### DIFF
--- a/Code/Python/Kamaelia/setup.py
+++ b/Code/Python/Kamaelia/setup.py
@@ -102,5 +102,144 @@ setup(name = "kamaelia",
                   ],
 #      scripts = ['Tools/KamaeliaPresent.py'],
       long_description = """
+Kamaelia, A fast overview
+=========================
+
+`Kamaelia <https://www.kamaelia.org/Home.html>`__ is a Python library by
+`BBC Research <http://www.bbc.co.uk/opensource/projects/kamaelia/>`__
+for concurrent programming using a simple pattern of components that
+send and receive data from each other.
+
+Note: this is the first alpha release of the Kamaelia 'refresh' project to
+bring Kamaelia up to date with the modern python ecosystem.
+
+A quick overview
+================
+
+| The following is an example of a system made by piping the output of
+  one component into another:
+
+   ::
+
+      from Kamaelia.Chassis.Pipeline import Pipeline
+      from Kamaelia.Util.Console import ConsoleReader, ConsoleEchoer
+
+      Pipeline(
+               ConsoleReader(),
+               ConsoleEchoer(),
+      ).run()
+
+Or maybe you want to build a presentation tool? (imports & setup
+excluded here)
+
+   ::
+
+      Graphline(
+           CHOOSER = Chooser(items = files),
+           IMAGE = Image(size=(800,600), position=(8,48)),
+           NEXT = Button(caption="Next", msg="NEXT", position=(72,8)),
+           PREVIOUS = Button(caption="Previous", msg="PREV",position=(8,8)),
+           FIRST = Button(caption="First", msg="FIRST",position=(256,8)),
+           LAST = Button(caption="Last", msg="LAST",position=(320,8)),
+           linkages = {
+              ("NEXT","outbox") : ("CHOOSER","inbox"),
+              ("PREVIOUS","outbox") : ("CHOOSER","inbox"),
+              ("FIRST","outbox") : ("CHOOSER","inbox"),
+              ("LAST","outbox") : ("CHOOSER","inbox"),
+              ("CHOOSER","outbox") : ("IMAGE","inbox"),
+           }
+      ).run()
+
+| That's all well and good, but how is a component written? What's
+  inside it?
+
+   ::
+
+      from Axon.Component import component
+      from Axon.Ipc import shutdownMicroprocess, producerFinished
+
+      class MyComponent(component):    
+          Inboxes = {"inbox"        : "some data in",
+                     "control"      : "stops the component"}
+          Outboxes = {"outbox"      : "some data out",
+                      "signal"      : "Shutdown signal"}
+
+          def __init__(self, **argd):
+              super(MyComponent, self).__init__(**argd)
+
+          def main(self):
+              while not self.doShutdown():
+                  if self.dataReady("inbox"):
+                      data = self.recv("inbox")
+                      # let's echo what we received...
+                      self.send(data, 'outbox')
+
+                  if not self.anyReady():
+                      self.pause()
+
+                  yield 1
+
+          def doShutdown(self):
+              if self.dataReady("control"):
+                  mes = self.recv("control")
+                  if isinstance(mes, shutdownMicroprocess) or isinstance(mes, producerFinished):
+                      self.send(producerFinished(), "signal")
+                      return True
+              return False
+
+This is the simplest form a component can take. A component:
+
+-  is a class that inherits from ``Axon.Component.component``
+-  has inboxes and outboxes
+
+By inheriting from ``Axon.Component.component`` you make your class
+usable by the Axon library which is at the core of the
+Kamaelia library. It allows for your class to be used with other
+components.
+
+Inboxes and outboxes allow your component to be linked to and from by
+other components.
+
+Then your class defines a main method that simple loop until a specific
+kind of message is put into the "control" inbox of the component. During
+the looping it checks for any inboxes and process data read from them.
+Eventually it yields to the Axon scheduler that goes to the next
+available component. By using a generator we allow the shceduler to come
+back to the component's loop eventually.
+
+Note that inboxes and outboxes are pure Python dictionary hence they
+allow for any Python objects and are not limited to strings. The
+component described above is simple, complex components have many
+inboxes and outboxes to link to and from.
+
+Kamaelia
+--------
+
+Kamaelia is a library of components for `all kind of tasks and
+topics <https://kamaelia.org/Components.html>`__:
+
+For example taking the previous example we could write:
+
+   ::
+
+      from Kamaelia.Chassis.Pipeline import Pipeline
+      from Kamaelia.Util.Console import ConsoleReader, ConsoleEchoer
+
+      Pipeline(
+               ConsoleReader(),
+               MyComponent(),
+               ConsoleEchoer(),
+      ).run()
+
+`Pipeline <https://kamaelia.org/Components/pydoc/Kamaelia.Chassis.Pipeline.html>`__
+is component that automatically links outboxes to inboxes of each
+provided component. The console components allow for reading and writing
+data from and to the command line. Because ``Pipeline`` is also a
+component itself it could in turns be used in another component.
+
+Note that calling the ``run()`` method on a component blocks the process
+until it is killed. You can also simply activate a component which will
+then be in an active state but will run only when eventually ``run`` is
+called on another component.
 """
       )

--- a/Website/markdown/Home.md
+++ b/Website/markdown/Home.md
@@ -23,6 +23,8 @@ What sort of systems? Network servers, clients, desktop applications,
 pygame based games, transcode systems and pipelines, digital TV systems,
 [spam eradicators](/KamaeliaGrey.html), [teaching
 tools](/SpeakAndWrite.html), and a fair amount more :)
+
+Current Release: [1.14.32 (2024/3/24)](https://github.com/sparkslabs/kamaelia/releases/tag/v1.14.32)
 :::
 :::
 
@@ -74,7 +76,7 @@ Kamaelia Documentation
 
 ### Documentation
 
-Documentation is a core asset in Kamaelia. As of Jan 2024, this is now
+Documentation is a core asset in Kamaelia. As of March 2024, this is now
 being significantly updated.
 
 While this is done you are invited to look at the [Component
@@ -128,13 +130,20 @@ Community
 
 ### Kamaelia is open source, help us improve it!
 
-### [Developer Central](/Developers/)
+### [Source](/Repository.html) 
 
-Interested in helping out? You\'re more than welcome! In this area
-you\'ll find some pages which cover some areas of interest for ongoing
-dev, our general development process, project management process,
-guidelines on contributing (eg smart questions, through to code, and
-contributor agreements)
+Kamaelia\'s source is hosted on
+[Github](https://github.com/sparkslabs/kamaelia/). 
+
+### [Release](/Releases.html)
+
+The first release of the Kamaelia \"refresh\" project has been made:
+
+* Github: [1.14.32 (2024/3/24)](https://github.com/sparkslabs/kamaelia/releases/tag/v1.14.32)
+* PyPI - 2 packages [kamaelia-axon](https://pypi.org/project/kamaelia-axon/) and [kamaelia](https://pypi.org/project/kamaelia/)
+
+These assume Python 3 only. This should be considered an alpha release.
+The older python2.7 releases are no longer supported with immediate effect.
 
 ### [Get Help (Contact)](/Contact.html)
 
@@ -144,14 +153,27 @@ repo.
 
 ### [Summer of Code](/SummerOfCode.html)
 
-We\'ve been involved with GSOC now for 3 years, and it\'s been great.
-One of the less obvious things about GSOC is that it\'s generated a
-wealth of docs and ideas which can be dived into here.
+We\'ve were involved with GSOC some time ago.  We did this for 3 years
+running in 2006, 2007 and 2008. It generated a wealth of components,
+documentation and ideas that may still be of interest and are linked
+to here. More than anything it proved that Kamaelia was accessible to
+novice developers. This content is likely to move and be updated to
+reflect the modern ecosystem, but is likely interesting in the meantime.
 
-### [Source](/Repository.html)
+### [Community Console](/Developers/)
 
-Kamaelia\'s source is hosted on
-[Github](https://github.com/sparkslabs/kamaelia/). The latest release is
+<i>(Please note - this section is somewhat out of date as of 2024, and 
+will be updated. However, it does accurately reflect how Kamaelia's
+primary development phase was managed)</i>
+
+Interested in helping out? You\'re more than welcome! In this area
+you\'ll find some pages which cover some areas of interest for ongoing
+dev, our general development process, project management process,
+guidelines on contributing (eg smart questions, through to code, and
+contributor agreements)
+
+<!--
+The latest release is
 somewhat out of data at this point and is to be used (with caution) with
 Python 2.7. That release is the [1.0.12.0
 release](/release/MonthlyReleases/Kamaelia-1.0.12.0.tar.gz). (Y.Y.M.r).
@@ -173,6 +195,8 @@ In the mean time:
 See also [getting started](/GetKamaelia.html))
 
 Other [releases](/release/) and [downloads](/downloads/).
+-->
+
 :::
 :::
 

--- a/Website/markdown/RecentChanges.md
+++ b/Website/markdown/RecentChanges.md
@@ -7,6 +7,39 @@ page-status: current
 ---
 # Recent Changes
 
+## 2024/03/24 - NEW Release 1.14.32 Made
+
+1.14.32 has been tagged and released on PyPI and is building on the PPA.
+This release brings semantic versioning to both Kamaelia and Axon. Significant
+updates to Kamaelia and Axon for modern python ecosystem have been made as part
+of this.
+
+This marks the first alpha release of this ongoing "Kamaelia refresh project".
+The best guide as to the current status is in the examples directory and is best
+viewed in two halves:
+
+* Filenames or Directories beginning with a leading underscore `_` are considered "disabled".
+  Specifically they are known not to function or not to function correctly with
+  a modern python ecosystem. There can be many reasons for this, but the primary
+  one is a depenendency on an external library, codebase (or old syntax), or
+  service that no longer functions that way, or no longer exists as it once
+  did. (examples include PyMedia, OpenGL AIM, plain (non-SSL) http services
+  and so on)
+
+  Some of these may be re-enabled in newer releases. Some will likely be removed
+  in newer releases.
+
+* Filenames / Directories without a leading underscore are known to function as
+  of 24/3/24.
+
+As it stands though, this is very much a functional release - and includes
+minor updates to code not changed in 20 years to function correctly with
+python 3. (The code stll functioned correctly with python 2 before these
+changes. Code that is stable for 20 years aside from that is a remarkable
+track record for a piece of code)
+
+## Note:
+
 **Current status:** This site is currently undergoing a number of updates
 and upgrades.  After this the plan is to bring the Kamaelia codebase up to
 date relative to changes in the python eco system since the project was put
@@ -18,6 +51,9 @@ supported version.  Then the pandemic hit, and frankly, there were more
 important things to worry about.  The pandemic is still with us, but
 circumstances have changed, making updates at the moment practical and
 realistic to achieve, so this has been done.
+
+
+
 
 
 ## Upcoming changes

--- a/Website/markdown/Releases.md
+++ b/Website/markdown/Releases.md
@@ -9,18 +9,27 @@ page-status: current|legacy|needsupdate|deprecated|recommended
 
 ## Current Releases
 
-### Core Library
+### 2024/03/24
 
-* Axon: 1.13.31
+* **Core Library** -- Axon: 1.14.32 (2024/03/24)
+* **Component Library** -- Kamaelia: 1.14.32 (2024/03/24)
 
-### Component Library
+## Downloads:
 
-* Kamaelia: 1.13.31
+The first release of the Kamaelia \"refresh\" project has been made:
 
+* Github: [1.14.32 (2024/3/24)](https://github.com/sparkslabs/kamaelia/releases/tag/v1.14.32)
+* PyPI - 2 packages [kamaelia-axon](https://pypi.org/project/kamaelia-axon/) and [kamaelia](https://pypi.org/project/kamaelia/)
+* Debian packages can be built from the repo
+
+These assume Python 3 only. This should be considered an alpha release.
+The older python 2.7 releases are no longer supported with immediate effect.
+
+<!--
 ### Applications
 
 * 
-
+-->
 
 ## Historical Note
 
@@ -49,8 +58,10 @@ Semantic versioning tends to deal with by default.
 
 ## Version Mapping
 
-* Kamaelia's last official release was version: 1.0.12.0
-* Axon's last official release was version: 1.7.1
+**Prior to the refresh, the last releases were**:
+
+* Kamaelia's : 1.0.12.0
+* Axon's : 1.7.1
 
 To simplify things, for both Axon & Kamaelia:
 
@@ -59,20 +70,22 @@ To simplify things, for both Axon & Kamaelia:
 * Patch version will be a count of the number of releases that are listed
   below. That count is 30 (19 + 11)
 
-That means the new release version numbers for BOTH Kamaelia and Axon going
-forward will initially be:
+The base version for the new versioning following semantic versioning
+was rationalised as follows: The new BASE release version numbers for BOTH
+Kamaelia and Axon going forward was chosen to be 1.13.31 . The reason for 31
+not 30, is because this is will be the 31st release.
 
-* 1.13.31
+Since then we've had a public release, which is 1.14.32. Later iterations
+will increase as per "Semver rationale" above.
 
-The reason for 31 not 30, is because this is will be the 31st release.
 
-## Historical Releases
+## List of Releases
 
 ### Kamaelia
 
-19 versions:
+Releases:
 
-* 0.1.1 - 2004/12/24
+* 0.1.1 - 2004/12/24 - Initial public release
 * 0.1.2 - 2005/04/01
 * 0.2.0-ep - 2005/06/25
 * 0.2.0 - 2005/07/20
@@ -91,10 +104,11 @@ The reason for 31 not 30, is because this is will be the 31st release.
 * 1.0.12.0 - 2010/12/24
 * 1.1.2.0 - 2011/01/13
 * 1.12.0 - 2015/03/01 - Collapsed version number 
+* 1.14.32 - 2024/03/24 - First alpha release of the Kamaelia refresh project, first batch of modern python ecosystem fixes
 
 ### Axon
 
-11 Releases
+Releases:
 
 * 1.0.0 - 2004/12/24
 * 1.0.4 - 2005/06/02
@@ -107,4 +121,4 @@ The reason for 31 not 30, is because this is will be the 31st release.
 * 1.6.0 - 2010/07/22 - License change to Apache 2
 * 1.7.0 - 2011/02/15
 * 1.7.1 - 2015/03/01
-
+* 1.14.32 - 2024/03/24 - First alpha release of the Kamaelia refresh project, first batch of modern python ecosystem fixes


### PR DESCRIPTION
Update website to cover new release. 

1.14.32 has been tagged and released on PyPI and is building on the PPA. This release brings semantic versioning to both Kamaelia and Axon. Significant updates to Kamaelia and Axon for modern python ecosystem have been made as part of this.
